### PR TITLE
Fix QSslCertificate::fromPath deprecated 

### DIFF
--- a/qsslserver.cpp
+++ b/qsslserver.cpp
@@ -30,7 +30,7 @@ void QSslServer::setLocalCertificateChain(const QList<QSslCertificate> &localCha
 	_configuration.setLocalCertificateChain(localChain);
 }
 
-void QSslServer::setLocalCertificateChain(const QString &fileName, QSsl::EncodingFormat format, QRegExp::PatternSyntax syntax)
+void QSslServer::setLocalCertificateChain(const QString &fileName, QSsl::EncodingFormat format, QSslCertificate::PatternSyntax syntax)
 {
 	_configuration.setLocalCertificateChain(QSslCertificate::fromPath(fileName, format, syntax));
 }
@@ -82,7 +82,7 @@ QSslKey QSslServer::privateKey() const
 	return _configuration.privateKey();
 }
 
-bool QSslServer::addCaCertificates(const QString &path, QSsl::EncodingFormat format, QRegExp::PatternSyntax syntax)
+bool QSslServer::addCaCertificates(const QString &path, QSsl::EncodingFormat format, QSslCertificate::PatternSyntax syntax)
 {
 	auto certs = QSslCertificate::fromPath(path, format, syntax);
 	if (!certs.isEmpty()) {

--- a/qsslserver.h
+++ b/qsslserver.h
@@ -22,7 +22,7 @@ public:
 	void setLocalCertificateChain(const QList<QSslCertificate> &localChain);
 	void setLocalCertificateChain(const QString &fileName,
 								  QSsl::EncodingFormat format = QSsl::Pem,
-								  QRegExp::PatternSyntax syntax = QRegExp::FixedString);
+								  QSslCertificate::PatternSyntax syntax = QSslCertificate::PatternSyntax::FixedString);
 	QList<QSslCertificate> localCertificateChain() const;
 
 	void setLocalCertificate(const QSslCertificate &certificate);
@@ -41,7 +41,7 @@ public:
 	// CA settings
 	bool addCaCertificates(const QString &path,
 						   QSsl::EncodingFormat format = QSsl::Pem,
-						   QRegExp::PatternSyntax syntax = QRegExp::FixedString);
+						   QSslCertificate::PatternSyntax syntax = QSslCertificate::PatternSyntax::FixedString);
 	void addCaCertificate(const QSslCertificate &certificate);
 	void addCaCertificates(const QList<QSslCertificate> &certificates);
 


### PR DESCRIPTION
https://doc.qt.io/qt-5/qsslcertificate-obsolete.html

Qt intagrated a special RegExp into QSslCertificate class

QRegExp:: just need to be replaced by QSslCertificate::PatternSyntax::